### PR TITLE
Add FluentD logging option

### DIFF
--- a/lib/cli/loader.js
+++ b/lib/cli/loader.js
@@ -91,10 +91,15 @@ class CliLoader {
 
         // Cache all init and command modules
         try {
-            _.each(this.options.directories, this._storeCommands.bind(this));
             if (this.options.main) {
                 cliUtils.applyToNodeModulesSync(this.options.main, this._storeCommands.bind(this));
             }
+            _.each(this.options.directories, directory => {
+                if (directory === this.options.main) {
+                    return;
+                }
+                this._storeCommands(directory);
+            });
         } catch (error) {
             return Q.reject(new Error(`Failed to load CLI commands: ${error.message}`, error.stack)).nodeify(callback);
         }

--- a/lib/log/logger.js
+++ b/lib/log/logger.js
@@ -12,7 +12,9 @@
 
 const path = require('path'),
     fs = require('fs'),
-    winston = require('winston');
+    _ = require('lodash'),
+    winston = require('winston'),
+    FluentTransport = require('fluent-logger').support.winstonTransport();
 
 function mkdirSync(path) {
     try {
@@ -25,19 +27,29 @@ function mkdirSync(path) {
 }
 
 class Logger extends winston.Logger {
-    constructor(logDirectory) {
+    constructor(options = {}) {
+        options = _.defaults(options, {
+            fluentD: {
+                host: 'localhost',
+                port: 24224,
+                timeout: 3.0,
+                tag: 'labshare'
+            },
+            logDirectory: null
+        });
+        
         let winstonTransports = [
             new winston.transports.Console({
                 colorize: true
             })
         ];
 
-        if (logDirectory) {
+        if (options.logDirectory) {
             // Create the log directory if it doesn't exist
-            mkdirSync(logDirectory);
+            mkdirSync(options.logDirectory);
 
             winstonTransports.push(new winston.transports.File({
-                filename: path.resolve(logDirectory, 'shell.log'),
+                filename: path.resolve(options.logDirectory, 'lsc.log'),
                 "timestamp": true,
                 "json": false,
                 "maxfiles": 5,
@@ -45,6 +57,8 @@ class Logger extends winston.Logger {
                 "level": "info"
             }));
         }
+
+        winstonTransports.push(new FluentTransport(options.fluentD.tag, options.fluentD));
 
         super({
             transports: winstonTransports

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lsc",
   "namespace": "lsc",
   "main": "./",
-  "version": "v0.16.714",
+  "version": "v0.16.921",
   "description": "Lab Share Command",
   "contributors": "https://github.com/LabShare/lsc/graphs/contributors",
   "repository": {
@@ -25,6 +25,7 @@
   "dependencies": {
     "flatiron": "^0.4.2",
     "flatiron-cli-config": "^0.1.5",
+    "fluent-logger": "^2.0.1",
     "glob": "^7.0.3",
     "gulp": "^3.9.1",
     "gulp-conflict": "^0.4.0",

--- a/sample-config.json
+++ b/sample-config.json
@@ -1,1 +1,10 @@
-{}
+{
+  "Log": {
+    "Path": "",
+    "FluentD": {
+      "host": "localhost",
+      "port": 24224,
+      "timeout": 3.0
+    }
+  }
+}


### PR DESCRIPTION
 - Update sample config
 - Fix duplicated module loading when `lsc` is run with itself as the root directory