### PR TITLE
Ensure the user is running Node.js 6+ when using LSC

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -156,7 +156,7 @@
     "no-prototype-builtins": "off",
     "no-restricted-globals": "error",
     "no-restricted-imports": "error",
-    "no-restricted-modules": "error",
+    "no-restricted-modules": "off",
     "no-restricted-syntax": "error",
     "no-return-assign": "error",
     "no-script-url": "error",

--- a/lib/bin/lsc.js
+++ b/lib/bin/lsc.js
@@ -2,6 +2,14 @@
 
 'use strict';
 
-const start = require('../cli').Start;
+const semver = require('semver'),
+    fs = require('fs'),
+    path = require('path'),
+    manifestPath = path.join(__dirname, '..', '..', 'package.json'),
+    requiredNodeVersion = JSON.parse(fs.readFileSync(manifestPath)).engines.node;
 
-start();
+if (!semver.satisfies(process.versions.node, requiredNodeVersion)) {
+    throw new Error('LSC requires Node 6 or higher installed!');
+}
+
+require('../cli').Start();

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lsc",
   "namespace": "lsc",
   "main": "./",
-  "version": "v0.16.1005",
+  "version": "v0.16.1201",
   "description": "Lab Share Command",
   "contributors": "https://github.com/LabShare/lsc/graphs/contributors",
   "repository": {
@@ -12,6 +12,10 @@
   "preferGlobal": true,
   "bugs": {
     "url": "https://github.com/LabShare/lsc/issues"
+  },
+  "engines": {
+    "npm": ">=3.7.0",
+    "node": ">=6.0.0"
   },
   "license": "MIT",
   "scripts": {
@@ -26,7 +30,7 @@
     "flatiron": "^0.4.2",
     "flatiron-cli-config": "^0.1.5",
     "fluent-logger": "^2.0.1",
-    "glob": "^7.0.3",
+    "glob": "^7.1.1",
     "gulp": "^3.9.1",
     "gulp-conflict": "^0.4.0",
     "gulp-rename": "^1.2.2",
@@ -35,17 +39,16 @@
     "json-override": "^0.2.0",
     "lodash": "^4.12.0",
     "q": "^1.4.1",
+    "semver": "^5.3.0",
+    "shelljs": "^0.6.0",
     "underscore.string": "^3.3.4",
-    "yargs": "^4.3.2",
-    "shelljs": "^0.6.0"
+    "yargs": "^4.3.2"
   },
   "devDependencies": {
     "istanbul": "^0.4.2",
     "jasmine-core": "^2.2.0",
     "jasmine-node": "^1.14.5",
     "mock-fs": "^3.9.0",
-    "promise-matchers": "^0.9.5",
-    "proxyquire": "^1.4.0",
-    "sinon": "^1.14.1"
+    "proxyquire": "^1.4.0"
   }
 }


### PR DESCRIPTION
Throw an exception at start up if the minimum version of Node.js is not installed.

 - Update node-glob
 - Remove unused devDependencies: sinon and promise-matchers