### PR TITLE
Add ability to specify the path to a local configuration file to lsc

### DIFF
--- a/cli/init.js
+++ b/cli/init.js
@@ -8,13 +8,23 @@ const _ = require('lodash'),
     path = require('path'),
     configLoader = require('../lib/config').Loader,
     {Logger} = require('../lib/log'),
+    yargs = require('yargs'),
     lscRoot = path.join(__dirname, '..');
 
 module.exports = function init() {
-    let config = configLoader.sync({
-        main: process.cwd(),
-        directories: [lscRoot]
-    });
+    let argv = yargs.options({
+            configFile: {
+                alias: ['config', 'conf'],
+                describe: 'A path to a local configuration file',
+                type: 'string',
+                default: null
+            }
+        }).argv,
+        config = configLoader.sync({
+            main: process.cwd(),
+            directories: [lscRoot],
+            configFilePath: argv.configFile
+        });
 
     try {
         global.LabShare.Config = config;
@@ -23,8 +33,8 @@ module.exports = function init() {
         throw error;
     }
 
-    let logDirectory = _.get(global.LabShare, 'Config.lsc.Log.Path'),
-        fluentD = _.get(global.LabShare, 'Config.lsc.Log.FluentD', {});
+    let logDirectory = _.get(config, 'lsc.Log.Path'),
+        fluentD = _.get(config, 'lsc.Log.FluentD', {});
 
     global.LabShare.Logger = new Logger({
         logDirectory,

--- a/lib/cli/start.js
+++ b/lib/cli/start.js
@@ -6,8 +6,9 @@ const flatiron = require('flatiron'),
     {app} = flatiron,
     cwd = process.cwd(),
     cliUtils = require('../cli/utils'),
-    LabShare = require('../labshare'),
     lscRoot = path.join(__dirname, '..', '..');
+
+let labShare = require('../labshare');
 
 /**
  * @param {object} options
@@ -43,16 +44,18 @@ module.exports = function start(options = {}) {
         usage: [app.Title,
             '',
             'Usage:',
-            'lsc <command>       - run a command',
-            'lsc help            - list all commands',
-            'lsc help <command>  - display help for a specific command'
+            'lsc <command>            - run a command',
+            'lsc help                 - list all commands',
+            'lsc help <command>       - display help for a specific command',
+            '',
+            '   --config <file-path>  - load a JSON configuration file (optional)'
         ],
         version: true
     });
     app.use(require('flatiron-cli-config'));
     app.use(require('../cli').Plugin, options);
 
-    global.LabShare = LabShare;
+    global.LabShare = labShare;
 
     app.start();
 };

--- a/lib/cli/utils.js
+++ b/lib/cli/utils.js
@@ -47,7 +47,7 @@ exports.readJSON = function (filePath) {
  */
 exports.isPackageSync = function isPackageSync(directory) {
     try {
-        var manifest = exports.getPackageManifest(directory);
+        let manifest = exports.getPackageManifest(directory);
         return !!manifest;
     } catch (e) {
         return false;

--- a/lib/config/loader.js
+++ b/lib/config/loader.js
@@ -8,7 +8,7 @@
  *     "value": 3,
  *     "string": "a-string"
  * }
- * 
+ *
  * let configLoader = require('config-loader');
  *
  * // Synchronous version (throws exceptions)
@@ -21,6 +21,7 @@
 const _ = require('lodash'),
     path = require('path'),
     assert = require('assert'),
+    untildify = require('untildify'),
     override = require('json-override'),
     cliUtils = require('../cli/utils');
 
@@ -33,14 +34,14 @@ const _ = require('lodash'),
  * @param {Object} config Contains configuration data
  */
 function loadConfig(directory, config) {
-    var pkgConfigPath = cliUtils.getPackageConfigPath(directory),
+    let pkgConfigPath = cliUtils.getPackageConfigPath(directory),
         manifest = cliUtils.getPackageManifest(directory);
 
     if (!manifest) {
         return;
     }
 
-    var name = cliUtils.getPackageName(manifest),
+    let name = cliUtils.getPackageName(manifest),
         pkgConfig = config[name] || cliUtils.readJSON(pkgConfigPath);
 
     config[name] = pkgConfig || {};
@@ -52,13 +53,20 @@ function loadConfig(directory, config) {
  * @param {Object} options
  * @param {string} [options.packageDirectory] - A relative or absolute path to a directory containing LabShare
  * packages as subdirectories. Default: ''
- * @param {string} options.main - The current, top-level project directory
+ * @param {string} [options.main] - The current, top-level project directory
  * @param {Array} [directories] - A list of paths to LabShare packages that should be searched for CLI commands. Each directory
  * must contain a package.json to be considered valid. Default: []
+ * @param {string} [configFilePath] - A path to a configuration file. Configuration data in the file will be loaded
+ * first then any configuration files found in 'main' or 'directories' will be loaded next.
  * @constructor
  */
 class ConfigLoader {
-    constructor(options={}) {
+    constructor(options = {}) {
+        if (options.configFilePath) {
+            assert.ok(_.isString(options.configFilePath), '`options.configFilePath` must be a string');
+            options.configFilePath = path.resolve(untildify(options.configFilePath));
+        }
+
         if (options.main) {
             assert.ok(_.isString(options.main), '`options.main` must be a string');
             options.main = path.resolve(options.main);
@@ -68,6 +76,7 @@ class ConfigLoader {
             assert.ok(_.isString(options.packageDirectory), '`options.packageDirectory` must be a string');
             options.packageDirectory = path.resolve(options.packageDirectory);
         }
+
         if (options.directories) {
             options.directories = _.isArray(options.directories) ? options.directories : [options.directories];
             options.directories = _.map(options.directories, directory => {
@@ -86,12 +95,20 @@ class ConfigLoader {
     sync() {
         let config = {};
 
+        if (this.options.configFilePath) {
+            config = cliUtils.readJSON(this.options.configFilePath);
+            if (!config) {
+                throw new Error(`Failed to load config file from "${this.options.configFilePath}"`);
+            }
+        }
+
         try {
             if (this.options.main) {
                 cliUtils.applyToNodeModulesSync(this.options.main, directory => {
                     loadConfig(directory, config);
                 });
             }
+
             _.each(this.options.directories, (directory) => {
                 loadConfig(directory, config);
             });
@@ -115,15 +132,16 @@ class ConfigLoader {
      * _overrideValues(config)
      * >>> { pack1: { val: 'new' }, pack2: {} }
      *
-     * @param {Object} config - it contains package configuration data
+     * @param {Object} config - object containing package configuration data
      * @private
      */
     _overrideValues(config) {
-        // Remove all the 'config overrides' to ensure the resulting config object is tidy
         _.each(config, (packageConfig, packageName) => {
             _.each(packageConfig, (value, key) => {
                 if (_.has(config, key)) {
                     config[key] = override(config[key], value);
+
+                    // Remove all the 'config overrides' to ensure the resulting config object is tidy
                     delete config[packageName][key];
                 }
             });
@@ -133,7 +151,7 @@ class ConfigLoader {
 
 // Expose the sync version and the constructor
 module.exports.sync = function configLoaderSync(options) {
-    var configLoader = new ConfigLoader(options);
+    let configLoader = new ConfigLoader(options);
     return configLoader.sync();
 };
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lsc",
   "namespace": "lsc",
   "main": "./",
-  "version": "v0.16.1201",
+  "version": "v0.17.0112",
   "description": "Lab Share Command",
   "contributors": "https://github.com/LabShare/lsc/graphs/contributors",
   "repository": {
@@ -27,6 +27,7 @@
     "lsc": "./lib/bin/lsc.js"
   },
   "dependencies": {
+    "eslint-plugin-promise": "^1.3.2",
     "flatiron": "^0.4.2",
     "flatiron-cli-config": "^0.1.5",
     "fluent-logger": "^2.0.1",
@@ -42,7 +43,8 @@
     "semver": "^5.3.0",
     "shelljs": "^0.6.0",
     "underscore.string": "^3.3.4",
-    "yargs": "^4.3.2"
+    "untildify": "^3.0.2",
+    "yargs": "^4.8.1"
   },
   "devDependencies": {
     "istanbul": "^0.4.2",

--- a/test/fixtures/local-config.json
+++ b/test/fixtures/local-config.json
@@ -1,0 +1,8 @@
+{
+  "pack1": {
+    "a": "b"
+  },
+  "cli-package2": {
+    "value": "asdef"
+  }
+}

--- a/test/lib/unit/config/loader_spec.js
+++ b/test/lib/unit/config/loader_spec.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const path = require('path');
+
 describe('configLoader', () => {
 
     let configLoaderSync,
@@ -76,6 +78,34 @@ describe('configLoader', () => {
 
             config['cli-package1'] = null;
             expect(config['cli-package1']).toBeNull();
+        });
+
+    });
+
+    describe('after loading configuration from a file path', () => {
+
+        beforeEach(() => {
+            config = configLoaderSync({
+                main: packagePath,
+                configFilePath: path.join('test', 'fixtures', 'local-config.json')
+            });
+        });
+
+        it('applies normalization and overrides package configuration by name', () => {
+            expect(config['pack1']).toEqual({
+                a: 'b'
+            });
+
+            // It still loaded the cli-package1 and cli-package2 configurations since the 'main' option was provided
+            expect(config['cli-package1']).toEqual(cliPackage1ConfigExpectation);
+
+            // The 'configFilePath' config file data replaced cli-package2's configuration
+            expect(config['cli-package2']).toEqual({
+                value: 'asdef',
+                Listen: {
+                    Port: 9999
+                }
+            });
         });
 
     });


### PR DESCRIPTION
Example:
lsc --config=~/path/to/local-config.json

The values from the config file are loaded first. Configuration values
in the current directory's config.json are loaded second. This change
allows config files to be stored in a central location instead of forcing
them to be stored in the root directory of LabShare packages.

 - Update unit tests
 - Minor refactoring