### PR TITLE
Use Shorter Json Result From Registry

### DIFF
--- a/lib/check-self-update/fetch-module-registry-info.js
+++ b/lib/check-self-update/fetch-module-registry-info.js
@@ -9,7 +9,7 @@ const tiny = require('tiny-json-http'),
  * @param {String} name
  */
 const fetchModuleRegistryInfo = (name) => {
-    const url = [REGISTRY_URL, name].join('/');
+    const url = [REGISTRY_URL, name, 'latest'].join('/');
     return Q.nfcall(tiny.get, {url}).then(result => result.body);
 };
 

--- a/lib/check-self-update/prompt-if-newer-version.js
+++ b/lib/check-self-update/prompt-if-newer-version.js
@@ -12,7 +12,7 @@ function hasNewerVersion(currentVersion, latestVersion) {
  * @private
  */
 function getLatestVersion(json) {
-    return correctVersion(json['dist-tags'].latest);
+    return correctVersion(json['version']);
 }
 
 function getModuleCurrentVersion() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lsc",
-  "version": "v0.17.0630",
+  "version": "v0.16.0717",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Npm has a shorter url for the latest package, which gives us a small performance improvement for the update check