### PR TITLE
fix(loader): resolves "callback already called" exception SHELL-1614

### DIFF
--- a/lib/cli/loader-plugin.ts
+++ b/lib/cli/loader-plugin.ts
@@ -51,7 +51,8 @@ exports.init = async function init(done) {
 
         done();
     } catch (error) {
-        done(error);
+        // TODO: workaround for async/await incompatibility with callbacks in the Flatiron CLI library
+        console.error(error);
     }
 };
 


### PR DESCRIPTION
Resolves "callback already called" errors when there is an uncaught exception on startup.